### PR TITLE
Load threads on viewDidLoad and minor style fixes

### DIFF
--- a/iOS/Charter/Charter/Base.lproj/LaunchScreen.storyboard
+++ b/iOS/Charter/Charter/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="ezH-MC-cIn">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="ezH-MC-cIn">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Table View Controller-->
@@ -13,6 +12,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <view key="tableFooterView" contentMode="scaleToFill" id="m8T-gf-CDt" userLabel="Footer">
+                            <rect key="frame" x="0.0" y="136" width="600" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="M7X-U6-Fqi">
                                 <rect key="frame" x="0.0" y="92" width="600" height="44"/>

--- a/iOS/Charter/Charter/Mailing Lists View Controller/MailingListsViewController.swift
+++ b/iOS/Charter/Charter/Mailing Lists View Controller/MailingListsViewController.swift
@@ -30,6 +30,7 @@ class MailingListsViewController: UIViewController, UITableViewDataSource, UITab
         tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: MailingListsViewController.reuseIdentifier)
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.tableFooterView = UIView(frame: .zero)
         
         navigationItem.title = Localizable.Strings.mailingLists
     }

--- a/iOS/Charter/Charter/Threads View Controller/ThreadsViewController.swift
+++ b/iOS/Charter/Charter/Threads View Controller/ThreadsViewController.swift
@@ -51,6 +51,7 @@ class ThreadsViewController: UIViewController, UITableViewDelegate, UISearchBarD
         
         tableView.estimatedRowHeight = 80
         tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.tableFooterView = UIView(frame: .zero)
         
         updateSeparatorStyle()
         
@@ -79,6 +80,8 @@ class ThreadsViewController: UIViewController, UITableViewDelegate, UISearchBarD
     private func updateSeparatorStyle() {
         if dataSource.isEmpty {
             tableView.separatorStyle = .None
+        } else {
+            tableView.separatorStyle = .SingleLine
         }
     }
     

--- a/iOS/Charter/Charter/Threads View Controller/ThreadsViewController.swift
+++ b/iOS/Charter/Charter/Threads View Controller/ThreadsViewController.swift
@@ -64,6 +64,8 @@ class ThreadsViewController: UIViewController, UITableViewDelegate, UISearchBarD
         if refreshEnabled {
             tableView.addSubview(refreshControl)
         }
+        
+        didRequestRefresh(self)
     }
     
     override func viewWillDisappear(animated: Bool) {

--- a/iOS/Charter/Charter/Threads View Controller/ThreadsViewController.swift
+++ b/iOS/Charter/Charter/Threads View Controller/ThreadsViewController.swift
@@ -66,7 +66,12 @@ class ThreadsViewController: UIViewController, UITableViewDelegate, UISearchBarD
             tableView.addSubview(refreshControl)
         }
         
-        didRequestRefresh(self)
+        // Check whether we are running UI tests before performing an automatic refresh.
+        // If we refresh immediately the screenshots (which we take with Fastlane in doing the UI tests)
+        // will be in an undefined state.
+        if !NSUserDefaults.standardUserDefaults().boolForKey("FASTLANE_SNAPSHOT") {
+            didRequestRefresh(self)
+        }
     }
     
     override func viewWillDisappear(animated: Bool) {


### PR DESCRIPTION
- Load thread items automatically the first time a thread is loaded. I'd figure it be nice to not have to pull to refresh as soon as you open up a thread.
- On the mailing lists table view, don't show cell separators for empty cells.
- On threads table views, show cell separators when datasource is not empty.

Let me know what you think.

Cheers!
