### PR TITLE
added support for Swift Package Manager mailing list

### DIFF
--- a/Backend/importer/download.js
+++ b/Backend/importer/download.js
@@ -64,7 +64,7 @@ if (!outputDirectory) {
   return;
 }
 
-async.each(['swift-evolution', 'swift-users', 'swift-dev'], (list, callback) => {
+async.each(['swift-evolution', 'swift-users', 'swift-dev', 'swift-build-dev'], (list, callback) => {
   downloadURLs(path.join(outputDirectory, list), getURLs(list), callback);
 }, (err) => {
   if (err) {

--- a/Backend/importer/generate.js
+++ b/Backend/importer/generate.js
@@ -1,12 +1,12 @@
 /*
 
 This is the main script for creating a JSON file that can be imported into
-the database. It expects the following structure. $data_directory is the 
-directory you pass on the command line. It may vary. Everything else is 
+the database. It expects the following structure. $data_directory is the
+directory you pass on the command line. It may vary. Everything else is
 not designed to be tweaked, and expects data in a format loosely copying that
 of the lists.swift.org website. We will (hopefully remember to)
 provide scripts to download that data, so check the README for those.
-  
+
   - $data_directory/
     - swift-evolution/
       - Week-of-Mon-20151207.txt
@@ -21,7 +21,7 @@ provide scripts to download that data, so check the README for those.
       - Week-of-...txt
       - Week-of-...txt
 
-This script will write the contents of the JSON to the directory specified, 
+This script will write the contents of the JSON to the directory specified,
 using the mailing list identifiers as file names.
 
 node generate.js $data_directory $output_directory
@@ -39,7 +39,7 @@ const getTestFile = (name, callback) => {
   fs.readFile(path.join(__dirname, 'sample', name), 'utf8', callback);
 };
 
-const mailingLists = ['swift-evolution', 'swift-users', 'swift-dev'];
+const mailingLists = ['swift-evolution', 'swift-users', 'swift-dev', 'swift-build-dev'];
 
 function run(dataDirectory, outputDirectory) {
   async.each(mailingLists, (list, callback) => {

--- a/Backend/list-period.js
+++ b/Backend/list-period.js
@@ -1,16 +1,16 @@
 var moment = require('moment');
 
 /**
- * Converts a date to its most recent Monday and presents 
+ * Converts a date to its most recent Monday and presents
  * in the format `Week-of-Mon-20160208/009359`. Eventually, this method
  * will work for days/periods other than each Monday (which is why listId is required).
- * 
- * @param  {String} listId swift-evolution, swift-users, swift-dev
+ *
+ * @param  {String} listId swift-evolution, swift-users, swift-dev, swift-build-dev
  * @param  {Date} date     The date object to determine the period for
  * @return {String}        String of the format given above.
  */
 module.exports = function(listId, date) {
-  if (!(listId === 'swift-evolution' || listId === 'swift-dev' || listId === 'swift-users')) {
+  if (!(listId === 'swift-evolution' || listId === 'swift-dev' || listId === 'swift-users' || listId === 'swift-build-dev')) {
     throw new Error('list-period takes a valid list id as the first argument');
   }
 

--- a/iOS/Charter/Base.lproj/LocalizableStrings.strings
+++ b/iOS/Charter/Base.lproj/LocalizableStrings.strings
@@ -12,6 +12,7 @@ template-key = "template string";
 swift-evolution = "Swift Evolution";
 swift-users = "Swift Users";
 swift-dev = "Swift Dev";
+swift-build-dev = "Swift Build Dev";
 
 // MailingListsViewController.swift
 mailing-lists = "Mailing Lists";

--- a/iOS/Charter/Charter/Models/Email.swift
+++ b/iOS/Charter/Charter/Models/Email.swift
@@ -43,10 +43,6 @@ enum EmailError: ErrorType {
     case InvalidData
 }
 
-extension Email: Hashable {
-    override var hashValue: Int { return id.hashValue }
-}
-
 func ==(lhs: Email, rhs: Email) -> Bool {
     return lhs.id == rhs.id
 }

--- a/iOS/Charter/Charter/Models/MailingList.swift
+++ b/iOS/Charter/Charter/Models/MailingList.swift
@@ -20,11 +20,11 @@ struct _MailingList: MailingListType {
 
 enum MailingList: RawRepresentable {
     typealias RawValue = MailingListType
-    
-    case SwiftEvolution, SwiftUsers, SwiftDev
-    
-    static var cases: [MailingList] = [.SwiftEvolution, .SwiftUsers, .SwiftDev]
-    
+
+    case SwiftEvolution, SwiftUsers, SwiftDev, SwiftBuildDev
+
+    static var cases: [MailingList] = [.SwiftEvolution, .SwiftUsers, .SwiftDev, .SwiftBuildDev]
+
     init?(rawValue: MailingListType) {
         switch rawValue.identifier {
         case "swift-evolution":
@@ -33,11 +33,13 @@ enum MailingList: RawRepresentable {
             self = .SwiftUsers
         case "swift-dev":
             self = .SwiftDev
+        case "swift-build-dev":
+            self = .SwiftBuildDev
         default:
             return nil
         }
     }
-    
+
     var rawValue: MailingListType {
         switch self {
         case .SwiftEvolution:
@@ -46,6 +48,8 @@ enum MailingList: RawRepresentable {
             return _MailingList(identifier: "swift-users", name: Localizable.Strings.swiftUsers)
         case .SwiftDev:
             return _MailingList(identifier: "swift-dev", name: Localizable.Strings.swiftDev)
+        case .SwiftBuildDev:
+            return _MailingList(identifier: "swift-build-dev", name: Localizable.Strings.swiftBuildDev)
         }
     }
 }

--- a/iOS/Charter/Charter/Resources/Localizable.swift
+++ b/iOS/Charter/Charter/Resources/Localizable.swift
@@ -13,6 +13,7 @@ struct Localizable {
 		static let swiftEvolution = NSLocalizedString("swift-evolution", tableName: "LocalizableStrings", comment: "")
 		static let swiftUsers = NSLocalizedString("swift-users", tableName: "LocalizableStrings", comment: "")
 		static let swiftDev = NSLocalizedString("swift-dev", tableName: "LocalizableStrings", comment: "")
+    static let swiftBuildDev = NSLocalizedString("swift-build-dev", tableName: "LocalizableStrings", comment: "")
 		static let mailingLists = NSLocalizedString("mailing-lists", tableName: "LocalizableStrings", comment: "")
 		static let searching = NSLocalizedString("searching", tableName: "LocalizableStrings", comment: "")
 		static let noResults = NSLocalizedString("no-results", tableName: "LocalizableStrings", comment: "")

--- a/iOS/Charter/es.lproj/LocalizableStrings.strings
+++ b/iOS/Charter/es.lproj/LocalizableStrings.strings
@@ -12,6 +12,7 @@ template-key = "template string";
 swift-evolution = "Evolución Swift";
 swift-users = "Usuarios Swift";
 swift-dev = "Dev Swift";
+swift-build-dev = "Swift Build Dev";
 
 // MailingListsViewController.swift
 mailing-lists = "Listas";

--- a/iOS/Charter/pt-PT.lproj/LocalizableStrings.strings
+++ b/iOS/Charter/pt-PT.lproj/LocalizableStrings.strings
@@ -12,6 +12,7 @@ template-key = "template string";
 swift-evolution = "Evolução Swift";
 swift-users = "Utilizadores Swift";
 swift-dev = "Desenvolvimento Swift";
+swift-build-dev = "Desenvolvimento Swift Package Manager";
 
 // MailingListsViewController.swift
 mailing-lists = "Listas";


### PR DESCRIPTION
Hi. `swift-build-dev` is quite useful to track especially when you're interested in Swift Package Manager development. This pull requests adds support for this mailing list both in client and backend code. Cheers.
